### PR TITLE
bring emf model of rdb back into the repo of rdb api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
     <module>structure.emf</module>
     <module>structure.modifier.base</module>
     <module>structure.modifier.pojo</module>
+    <module>structure.modifier.emf</module>
   </modules>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
   <modules>
     <module>structure.api</module>
     <module>structure.pojo</module>
+    <module>structure.emf</module>
     <module>structure.modifier.base</module>
     <module>structure.modifier.pojo</module>
   </modules>

--- a/structure.emf/pom.xml
+++ b/structure.emf/pom.xml
@@ -23,10 +23,6 @@
 
   <properties>
     <bnd.version>7.1.0-SNAPSHOT</bnd.version>
-    <gecko.emf.version>6.2.0</gecko.emf.version>
-    <emf.common.version>2.30.0</emf.common.version>
-    <emf.ecore.version>2.36.0</emf.ecore.version>
-    <emf.ecore.xmi.version>2.37.0</emf.ecore.xmi.version>
   </properties>
 
 

--- a/structure.emf/pom.xml
+++ b/structure.emf/pom.xml
@@ -1,0 +1,150 @@
+<?xml version="1.0"?>
+<!--
+/*********************************************************************
+* Copyright (c) 2024 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+**********************************************************************/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.eclipse.daanse</groupId>
+    <artifactId>org.eclipse.daanse.rdb</artifactId>
+    <version>${revision}</version>
+  </parent>
+  <artifactId>org.eclipse.daanse.rdb.structure.emf</artifactId>
+
+  <properties>
+    <bnd.version>7.1.0-SNAPSHOT</bnd.version>
+    <gecko.emf.version>6.2.0</gecko.emf.version>
+    <emf.common.version>2.30.0</emf.common.version>
+    <emf.ecore.version>2.36.0</emf.ecore.version>
+    <emf.ecore.xmi.version>2.37.0</emf.ecore.xmi.version>
+  </properties>
+
+
+  <pluginRepositories>
+    <pluginRepository>
+      <id>bnd-snapshots</id>
+      <url>https://bndtools.jfrog.io/bndtools/libs-snapshot/</url>
+      <layout>default</layout>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+    </pluginRepository>
+  </pluginRepositories>
+  <dependencies>
+    <dependency>
+      <groupId>org.eclipse.daanse</groupId>
+      <artifactId>org.eclipse.daanse.rdb.structure.api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.geckoprojects.emf</groupId>
+      <artifactId>org.gecko.emf.osgi.api</artifactId>
+      <version>${gecko.emf.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.geckoprojects.emf</groupId>
+      <artifactId>org.gecko.emf.osgi.component</artifactId>
+      <version>${gecko.emf.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.emf</groupId>
+      <artifactId>org.eclipse.emf.common</artifactId>
+      <version>${emf.common.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.emf</groupId>
+      <artifactId>org.eclipse.emf.ecore</artifactId>
+      <version>${emf.ecore.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.emf</groupId>
+      <artifactId>org.eclipse.emf.ecore.xmi</artifactId>
+      <version>${emf.ecore.xmi.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.daanse</groupId>
+      <artifactId>org.eclipse.daanse.rdb.structure.api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>biz.aQute.bnd</groupId>
+        <artifactId>bnd-generate-maven-plugin</artifactId>
+        <version>${bnd.version}</version>
+        <configuration>
+          <externalPlugins>
+            <dependency>
+              <groupId>org.geckoprojects.emf</groupId>
+              <artifactId>org.gecko.emf.osgi.codegen</artifactId>
+              <version>${gecko.emf.version}</version>
+            </dependency>
+          </externalPlugins>
+          <steps>
+            <step>
+              <trigger>
+                src/main/resources/model/org.eclipse.daanse.rdb.structure.genmodel</trigger>
+              <generateCommand>geckoEMF</generateCommand>
+              <output>target/generated-sources/emf</output>
+              <clear>false</clear>
+              <properties>
+                <genmodel>
+                  src/main/resources/model/org.eclipse.daanse.rdb.structure.genmodel</genmodel>
+              </properties>
+            </step>
+          </steps>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>3.6.0</version>
+        <executions>
+          <execution>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>add-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>target/generated-sources/emf</source>
+              </sources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/structure.emf/src/main/java/org/eclipse/daanse/rdb/structure/emf/provider/api/Constants.java
+++ b/structure.emf/src/main/java/org/eclipse/daanse/rdb/structure/emf/provider/api/Constants.java
@@ -1,0 +1,22 @@
+/*
+* Copyright (c) 2024 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   SmartCity Jena - initial
+*   Stefan Bischof (bipolis.org) - initial
+*/
+package org.eclipse.daanse.rdb.structure.emf.provider.api;
+
+public class Constants {
+
+    public static final String RESOURCE_URL = "resource.url";
+
+    public static final String PID_EMF_DATABASE_CATALOG_PROVIDER = "org.eclipse.daanse.rdb.structure.emf.provider.EmfDatabaseStructureProvider";
+
+}

--- a/structure.emf/src/main/java/org/eclipse/daanse/rdb/structure/emf/provider/api/DatabaseStructureConfig.java
+++ b/structure.emf/src/main/java/org/eclipse/daanse/rdb/structure/emf/provider/api/DatabaseStructureConfig.java
@@ -1,0 +1,24 @@
+/*
+* Copyright (c) 2024 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   SmartCity Jena - initial
+*   Stefan Bischof (bipolis.org) - initial
+*/
+package org.eclipse.daanse.rdb.structure.emf.provider.api;
+
+import org.osgi.service.metatype.annotations.AttributeDefinition;
+import org.osgi.service.metatype.annotations.ObjectClassDefinition;
+
+@ObjectClassDefinition
+public @interface DatabaseStructureConfig {
+
+    @AttributeDefinition(name = Constants.RESOURCE_URL)
+    String resource_url();
+}

--- a/structure.emf/src/main/java/org/eclipse/daanse/rdb/structure/emf/provider/api/package-info.java
+++ b/structure.emf/src/main/java/org/eclipse/daanse/rdb/structure/emf/provider/api/package-info.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *
+ */
+@org.osgi.annotation.bundle.Export
+@org.osgi.annotation.versioning.Version("0.0.1")
+package org.eclipse.daanse.rdb.structure.emf.provider.api;
+

--- a/structure.emf/src/main/java/org/eclipse/daanse/rdb/structure/emf/provider/impl/EmfDatabaseStructureProvider.java
+++ b/structure.emf/src/main/java/org/eclipse/daanse/rdb/structure/emf/provider/impl/EmfDatabaseStructureProvider.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *
+ */
+package org.eclipse.daanse.rdb.structure.emf.provider.impl;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.eclipse.daanse.rdb.structure.api.DatabaseStructureProvider;
+import org.eclipse.daanse.rdb.structure.api.model.DatabaseCatalog;
+import org.eclipse.daanse.rdb.structure.emf.provider.api.Constants;
+import org.eclipse.daanse.rdb.structure.emf.rdbstructure.RelationalDatabasePackage;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.gecko.emf.osgi.constants.EMFNamespaces;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ServiceScope;
+import org.osgi.service.metatype.annotations.Designate;
+
+@Component(service = DatabaseStructureProvider.class, scope = ServiceScope.SINGLETON, configurationPid = Constants.PID_EMF_DATABASE_CATALOG_PROVIDER)
+@Designate(factory = true, ocd = org.eclipse.daanse.rdb.structure.emf.provider.api.DatabaseStructureConfig.class)
+public class EmfDatabaseStructureProvider implements DatabaseStructureProvider {
+
+    @Reference(target = "(" + EMFNamespaces.EMF_MODEL_NAME + "=" + RelationalDatabasePackage.eNAME + ")")
+    private ResourceSet resourceSet;
+
+    private DatabaseCatalog databaseCatalog;
+
+    @Activate
+    public void activate(org.eclipse.daanse.rdb.structure.emf.provider.api.DatabaseStructureConfig config) throws IOException {
+
+        URI uri = URI.createURI(config.resource_url());
+
+        Resource resource = resourceSet.getResource(uri, true);
+        resource.load(Map.of());
+
+        EObject root = resource.getContents().get(0);
+
+        if (root instanceof DatabaseCatalog databaseCatalog) {
+            this.databaseCatalog = databaseCatalog;
+        }
+    }
+
+    private void cleanAllResources() {
+        resourceSet.getResources().forEach(Resource::unload);
+    }
+
+    @Deactivate
+    public void deactivate() {
+        cleanAllResources();
+    }
+
+    @Override
+    public DatabaseCatalog get() {
+        return databaseCatalog;
+    }
+}

--- a/structure.emf/src/main/java/org/eclipse/daanse/rdb/structure/emf/provider/impl/package-info.java
+++ b/structure.emf/src/main/java/org/eclipse/daanse/rdb/structure/emf/provider/impl/package-info.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *
+ */
+package org.eclipse.daanse.rdb.structure.emf.provider.impl;

--- a/structure.emf/src/main/resources/model/org.eclipse.daanse.rdb.structure.ecore
+++ b/structure.emf/src/main/resources/model/org.eclipse.daanse.rdb.structure.ecore
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/*********************************************************************
+* Copyright (c) 2024 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+**********************************************************************/
+-->
+<ecore:EPackage xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" name="rdbstructure" nsURI="https://www.daanse.org/spec/org.eclipse.daanse.rdb.structure"
+    nsPrefix="rdbs">
+  <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <details key="qualified" value="true"/>
+  </eAnnotations>
+  <eClassifiers xsi:type="ecore:EClass" name="DatabaseCatalog" eSuperTypes="#//IDatabaseCatalog">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="schemas" upperBound="-1"
+        eType="#//DatabaseSchema" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="links" upperBound="-1"
+        eType="#//Link" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="DatabaseSchema" eSuperTypes="#//IDatabaseSchema">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="id" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"
+        iD="true"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="name" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="tables" upperBound="-1"
+        eType="#//Table" containment="true" eOpposite="#//Table/schema" eKeys="#//Table/name"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Table" abstract="true" eSuperTypes="#//ITable">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="id" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"
+        iD="true"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="name" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="description" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="columns" upperBound="-1"
+        eType="#//Column" containment="true" eOpposite="#//Column/table" eKeys="#//Column/name"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="schema" eType="#//DatabaseSchema"
+        eOpposite="#//DatabaseSchema/tables"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="PhysicalTable" eSuperTypes="#//IPhysicalTable #//Table"/>
+  <eClassifiers xsi:type="ecore:EClass" name="SystemTable" eSuperTypes="#//ISystemTable #//Table"/>
+  <eClassifiers xsi:type="ecore:EClass" name="ViewTable" eSuperTypes="#//IViewTable #//Table"/>
+  <eClassifiers xsi:type="ecore:EClass" name="Column" eSuperTypes="#//IColumn">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="id" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"
+        iD="true"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="name" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="type" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="typeQualifiers" upperBound="-1"
+        eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="description" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="table" eType="#//Table"
+        eOpposite="#//Table/columns"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="primaryLinks" upperBound="-1"
+        eType="#//Link"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="foreignLinks" upperBound="-1"
+        eType="#//Link" eOpposite="#//Link/primaryKey"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Link" eSuperTypes="#//ILink">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="primaryKey" lowerBound="1"
+        eType="#//Column" eOpposite="#//Column/foreignLinks"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="foreignKey" lowerBound="1"
+        eType="#//Column"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="IDatabaseCatalog" instanceClassName="org.eclipse.daanse.rdb.structure.api.model.DatabaseCatalog"
+      abstract="true" interface="true"/>
+  <eClassifiers xsi:type="ecore:EClass" name="IDatabaseSchema" instanceClassName="org.eclipse.daanse.rdb.structure.api.model.DatabaseSchema"
+      abstract="true" interface="true"/>
+  <eClassifiers xsi:type="ecore:EClass" name="ITable" instanceClassName="org.eclipse.daanse.rdb.structure.api.model.Table"
+      abstract="true" interface="true"/>
+  <eClassifiers xsi:type="ecore:EClass" name="IPhysicalTable" instanceClassName="org.eclipse.daanse.rdb.structure.api.model.PhysicalTable"
+      abstract="true" interface="true"/>
+  <eClassifiers xsi:type="ecore:EClass" name="IViewTable" instanceClassName="org.eclipse.daanse.rdb.structure.api.model.ViewTable"
+      abstract="true" interface="true"/>
+  <eClassifiers xsi:type="ecore:EClass" name="ISystemTable" instanceClassName="org.eclipse.daanse.rdb.structure.api.model.SystemTable"
+      abstract="true" interface="true"/>
+  <eClassifiers xsi:type="ecore:EClass" name="IColumn" instanceClassName="org.eclipse.daanse.rdb.structure.api.model.Column"
+      abstract="true" interface="true"/>
+  <eClassifiers xsi:type="ecore:EClass" name="ILink" instanceClassName="org.eclipse.daanse.rdb.structure.api.model.Link"
+      abstract="true" interface="true"/>
+</ecore:EPackage>

--- a/structure.emf/src/main/resources/model/org.eclipse.daanse.rdb.structure.genmodel
+++ b/structure.emf/src/main/resources/model/org.eclipse.daanse.rdb.structure.genmodel
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/*********************************************************************
+* Copyright (c) 2024 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+**********************************************************************/
+-->
+<genmodel:GenModel xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore"
+    xmlns:genmodel="http://www.eclipse.org/emf/2002/GenModel" copyrightText="Copyright (c) 2024 Contributors to the Eclipse Foundation.&#xA;&#xA;This program and the accompanying materials are made&#xA;available under the terms of the Eclipse Public License 2.0&#xA;which is available at https://www.eclipse.org/legal/epl-2.0/&#xA;&#xA;SPDX-License-Identifier: EPL-2.0&#xA;&#xA;Contributors:&#xA;"
+    modelDirectory="/org.eclipse.daanse.rdb.structure/src" modelPluginID="org.eclipse.daanse.rdb.structure"
+    modelName="org.eclipse.daanse.rdb.structure" rootExtendsClass="org.eclipse.emf.ecore.impl.MinimalEObjectImpl$Container"
+    importerID="org.eclipse.emf.importer.ecore" complianceLevel="17.0" copyrightFields="false"
+    operationReflection="true" importOrganizing="true" oSGiCompatible="true">
+  <foreignModel>org.eclipse.daanse.rdb.structure.ecore</foreignModel>
+  <genPackages prefix="RelationalDatabase" basePackage="org.eclipse.daanse.rdb.structure.emf"
+      resource="XML" disposableProviderFactory="true" ecorePackage="org.eclipse.daanse.rdb.structure.ecore#/">
+    <genClasses ecoreClass="org.eclipse.daanse.rdb.structure.ecore#//DatabaseCatalog">
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference org.eclipse.daanse.rdb.structure.ecore#//DatabaseCatalog/schemas"/>
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference org.eclipse.daanse.rdb.structure.ecore#//DatabaseCatalog/links"/>
+    </genClasses>
+    <genClasses ecoreClass="org.eclipse.daanse.rdb.structure.ecore#//DatabaseSchema">
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute org.eclipse.daanse.rdb.structure.ecore#//DatabaseSchema/id"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute org.eclipse.daanse.rdb.structure.ecore#//DatabaseSchema/name"/>
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference org.eclipse.daanse.rdb.structure.ecore#//DatabaseSchema/tables"/>
+    </genClasses>
+    <genClasses image="false" ecoreClass="org.eclipse.daanse.rdb.structure.ecore#//Table">
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute org.eclipse.daanse.rdb.structure.ecore#//Table/id"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute org.eclipse.daanse.rdb.structure.ecore#//Table/name"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute org.eclipse.daanse.rdb.structure.ecore#//Table/description"/>
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference org.eclipse.daanse.rdb.structure.ecore#//Table/columns"/>
+      <genFeatures property="None" notify="false" createChild="false" ecoreFeature="ecore:EReference org.eclipse.daanse.rdb.structure.ecore#//Table/schema"/>
+    </genClasses>
+    <genClasses ecoreClass="org.eclipse.daanse.rdb.structure.ecore#//PhysicalTable"/>
+    <genClasses ecoreClass="org.eclipse.daanse.rdb.structure.ecore#//SystemTable"/>
+    <genClasses ecoreClass="org.eclipse.daanse.rdb.structure.ecore#//ViewTable"/>
+    <genClasses ecoreClass="org.eclipse.daanse.rdb.structure.ecore#//Column">
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute org.eclipse.daanse.rdb.structure.ecore#//Column/id"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute org.eclipse.daanse.rdb.structure.ecore#//Column/name"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute org.eclipse.daanse.rdb.structure.ecore#//Column/type"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute org.eclipse.daanse.rdb.structure.ecore#//Column/typeQualifiers"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute org.eclipse.daanse.rdb.structure.ecore#//Column/description"/>
+      <genFeatures property="None" notify="false" createChild="false" ecoreFeature="ecore:EReference org.eclipse.daanse.rdb.structure.ecore#//Column/table"/>
+      <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference org.eclipse.daanse.rdb.structure.ecore#//Column/primaryLinks"/>
+      <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference org.eclipse.daanse.rdb.structure.ecore#//Column/foreignLinks"/>
+    </genClasses>
+    <genClasses ecoreClass="org.eclipse.daanse.rdb.structure.ecore#//Link">
+      <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference org.eclipse.daanse.rdb.structure.ecore#//Link/primaryKey"/>
+      <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference org.eclipse.daanse.rdb.structure.ecore#//Link/foreignKey"/>
+    </genClasses>
+    <genClasses image="false" ecoreClass="org.eclipse.daanse.rdb.structure.ecore#//IDatabaseCatalog"/>
+    <genClasses image="false" ecoreClass="org.eclipse.daanse.rdb.structure.ecore#//IDatabaseSchema"/>
+    <genClasses image="false" ecoreClass="org.eclipse.daanse.rdb.structure.ecore#//ITable"/>
+    <genClasses image="false" ecoreClass="org.eclipse.daanse.rdb.structure.ecore#//IPhysicalTable"/>
+    <genClasses image="false" ecoreClass="org.eclipse.daanse.rdb.structure.ecore#//IViewTable"/>
+    <genClasses image="false" ecoreClass="org.eclipse.daanse.rdb.structure.ecore#//ISystemTable"/>
+    <genClasses image="false" ecoreClass="org.eclipse.daanse.rdb.structure.ecore#//IColumn"/>
+    <genClasses image="false" ecoreClass="org.eclipse.daanse.rdb.structure.ecore#//ILink"/>
+  </genPackages>
+</genmodel:GenModel>

--- a/structure.emf/src/test/java/org/eclipse/daanse/rdb/structure/emf/AnnotationHelper.java
+++ b/structure.emf/src/test/java/org/eclipse/daanse/rdb/structure/emf/AnnotationHelper.java
@@ -1,0 +1,51 @@
+/*
+* Copyright (c) 2024 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   SmartCity Jena - initial
+*   Stefan Bischof (bipolis.org) - initial
+*/
+package org.eclipse.daanse.rdb.structure.emf;
+
+import static org.osgi.test.common.annotation.Property.ValueSource.SystemProperty;
+import static org.osgi.test.common.annotation.Property.ValueSource.TestClass;
+import static org.osgi.test.common.annotation.Property.ValueSource.TestMethod;
+import static org.osgi.test.common.annotation.Property.ValueSource.TestUniqueId;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import org.eclipse.daanse.rdb.structure.emf.provider.api.Constants;
+import org.osgi.test.common.annotation.Property;
+import org.osgi.test.common.annotation.Property.TemplateArgument;
+import org.osgi.test.common.annotation.config.WithFactoryConfiguration;
+
+public class AnnotationHelper {
+
+    public static final String PREFIX_MARKER_TESTING = "marker.testing.";
+    public static final String MARKER_TEST_CLASS = PREFIX_MARKER_TESTING + "TestClass";
+    public static final String MARKER_TEST_METHOD = PREFIX_MARKER_TESTING + "TestMethod";
+    public static final String MARKER_TEST_UNIQUEID = PREFIX_MARKER_TESTING + "TestUniqueId";
+    public static final String MARKER_TEST_UNIQUEID_HEX = PREFIX_MARKER_TESTING + "TestUniqueId.hex";
+
+    @WithFactoryConfiguration(location = "?", factoryPid = Constants.PID_EMF_DATABASE_CATALOG_PROVIDER, properties = {
+            @Property(key = Constants.RESOURCE_URL, value = "file:///%s/target/test-classes/%s/%s/instance.xmi", //
+                    templateArguments = { //
+                            @TemplateArgument(source = SystemProperty, value = "basePath"), //
+                            @TemplateArgument(source = TestClass), //
+                            @TemplateArgument(source = TestMethod) }),
+            @Property(key = MARKER_TEST_CLASS, source = TestClass), //
+            @Property(key = MARKER_TEST_METHOD, source = TestMethod), //
+            @Property(key = MARKER_TEST_UNIQUEID, source = TestUniqueId), //
+            @Property(key = MARKER_TEST_UNIQUEID_HEX, value = "%h", templateArguments = @TemplateArgument(source = TestUniqueId)), //
+    })
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface SetupMappingProviderWithTestInstance {
+    }
+}

--- a/structure.emf/src/test/java/org/eclipse/daanse/rdb/structure/emf/TestClass.java
+++ b/structure.emf/src/test/java/org/eclipse/daanse/rdb/structure/emf/TestClass.java
@@ -1,0 +1,24 @@
+/*
+* Copyright (c) 2024 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   SmartCity Jena - initial
+*   Stefan Bischof (bipolis.org) - initial
+*/
+package org.eclipse.daanse.rdb.structure.emf;
+
+import org.junit.jupiter.api.Test;
+
+public class TestClass {
+
+    @Test
+    void testName() throws Exception {
+
+    }
+}

--- a/structure.emf/src/test/java/org/eclipse/daanse/rdb/structure/emf/provider/EmfDatabaseStructureProviderTest.java
+++ b/structure.emf/src/test/java/org/eclipse/daanse/rdb/structure/emf/provider/EmfDatabaseStructureProviderTest.java
@@ -1,0 +1,77 @@
+/*
+* Copyright (c) 2024 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   SmartCity Jena - initial
+*   Stefan Bischof (bipolis.org) - initial
+*/
+package org.eclipse.daanse.rdb.structure.emf.provider;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.List;
+
+import org.eclipse.daanse.rdb.structure.api.DatabaseStructureProvider;
+import org.eclipse.daanse.rdb.structure.api.model.DatabaseCatalog;
+import org.eclipse.daanse.rdb.structure.api.model.DatabaseSchema;
+import org.eclipse.daanse.rdb.structure.api.model.PhysicalTable;
+import org.eclipse.daanse.rdb.structure.api.model.Table;
+import org.eclipse.daanse.rdb.structure.emf.AnnotationHelper.SetupMappingProviderWithTestInstance;
+import org.gecko.emf.osgi.annotation.require.RequireEMF;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.osgi.service.cm.annotations.RequireConfigurationAdmin;
+import org.osgi.service.component.annotations.RequireServiceComponentRuntime;
+import org.osgi.test.common.annotation.InjectService;
+import org.osgi.test.common.service.ServiceAware;
+import org.osgi.test.junit5.cm.ConfigurationExtension;
+import org.osgi.test.junit5.context.BundleContextExtension;
+import org.osgi.test.junit5.service.ServiceExtension;
+
+@ExtendWith(BundleContextExtension.class)
+@ExtendWith(ServiceExtension.class)
+@ExtendWith(ConfigurationExtension.class)
+@RequireEMF
+@RequireConfigurationAdmin
+@RequireServiceComponentRuntime
+public class EmfDatabaseStructureProviderTest {
+
+    private static String BASE_DIR = System.getProperty("basePath");
+
+    @SetupMappingProviderWithTestInstance
+    @Test
+    public void loadSimpleFile(
+            @InjectService(cardinality = 1, timeout = 2000) ServiceAware<DatabaseStructureProvider> saProvider)
+            throws SQLException, InterruptedException, IOException {
+        assertThat(saProvider.getServices()).hasSize(1);
+
+        DatabaseStructureProvider provider = saProvider.getService();
+
+        DatabaseCatalog databaseCatalog = provider.get();
+        List<? extends DatabaseSchema> dbSchemas = databaseCatalog.getSchemas();
+
+        assertThat(dbSchemas).hasSize(1);
+        DatabaseSchema dbSchema = dbSchemas.get(0);
+        assertThat(dbSchema).extracting(DatabaseSchema::getName).isEqualTo("s1n");
+
+        List<? extends Table> tables = dbSchema.getTables();
+
+        assertThat(tables).hasSize(2);
+
+        Table pt1 = tables.get(0);
+        assertThat(pt1).isInstanceOf(PhysicalTable.class).extracting(Table::getName).isEqualTo("pt1n");
+
+        Table pt2 = tables.get(1);
+        assertThat(pt2).isInstanceOf(PhysicalTable.class).extracting(Table::getName).isEqualTo("pt2n");
+
+    }
+
+}

--- a/structure.emf/src/test/resources/org.eclipse.daanse.rdb.structure.emf.provider.EmfDatabaseStructureProviderTest/loadSimpleFile/instance.xmi
+++ b/structure.emf/src/test/resources/org.eclipse.daanse.rdb.structure.emf.provider.EmfDatabaseStructureProviderTest/loadSimpleFile/instance.xmi
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/*********************************************************************
+* Copyright (c) 2024 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+**********************************************************************/
+-->
+<rdbs:DatabaseCatalog
+    xmi:version="2.0"
+    xmlns:xmi="http://www.omg.org/XMI"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:rdbs="https://www.daanse.org/spec/org.eclipse.daanse.rdb.structure"
+    xsi:schemaLocation="https://www.daanse.org/spec/org.eclipse.daanse.rdb.structure ../../../../main/resources/model/org.eclipse.daanse.rdb.structure.ecore">
+  <schemas id="s1"
+      name="s1n">
+    <tables
+        xsi:type="rdbs:PhysicalTable"
+        id="pt1"
+        name="pt1n">
+      <columns
+          id="c1"
+          name="c1n"
+          type="varchar"
+          foreignLinks="//@links.0">
+        <typeQualifiers>255</typeQualifiers>
+      </columns>
+    </tables>
+    <tables
+        xsi:type="rdbs:PhysicalTable"
+        id="pt2"
+        name="pt2n">
+      <columns
+          id="c2"
+          name="c2n"
+          type="varchar">
+        <typeQualifiers>255</typeQualifiers>
+      </columns>
+    </tables>
+  </schemas>
+  <links primaryKey="c1"
+      foreignKey="c2"/>
+</rdbs:DatabaseCatalog>

--- a/structure.emf/test.bndrun
+++ b/structure.emf/test.bndrun
@@ -68,7 +68,7 @@
 	org.eclipse.emf.common;version='[2.30.0,2.30.1)',\
 	org.eclipse.emf.ecore;version='[2.36.0,2.36.1)',\
 	org.eclipse.emf.ecore.xmi;version='[2.37.0,2.37.1)',\
-	org.gecko.emf.osgi.component;version='[6.2.0,6.2.1)',\
+	org.gecko.emf.osgi.component;version='[6.1.3,6.1.4)',\
 	org.opentest4j;version='[1.3.0,1.3.1)',\
 	org.osgi.service.component;version='[1.5.1,1.5.2)',\
 	org.osgi.test.common;version='[1.3.0,1.3.1)',\

--- a/structure.emf/test.bndrun
+++ b/structure.emf/test.bndrun
@@ -1,0 +1,79 @@
+#*******************************************************************************
+# Copyright (c)  2004 Contributors to the Eclipse Foundation
+#
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/ 
+# 
+# SPDX-License-Identifier: EPL-2.0
+#
+#   Contributors:
+#	 SmartCity Jena - initial
+#	 Stefan Bischof (bipolis.org) - initial
+#*******************************************************************************
+
+-runstartlevel: \
+	order=sortbynameversion,\
+	begin=-1
+
+-runtrace: true
+
+-tester: biz.aQute.tester.junit-platform
+
+# JaCoCo calculates test coverage
+-runpath.jacoco:\
+	org.jacoco.agent,\
+	org.jacoco.agent.rt
+
+-runvm.coverage: -javaagent:${repo;org.jacoco.agent.rt}=destfile=${target-dir}/jacoco.exec
+-runvm.base: -DbasePath=${.}
+
+-runpath.log: \
+	ch.qos.logback.classic,\
+	ch.qos.logback.core,\
+	slf4j.api
+
+-runproperties.logback:\
+	org.osgi.framework.bootdelegation=org.mockito.internal.creation.bytebuddy.inject,\
+	logback.configurationFile=${project.build.testOutputDirectory}/logback-test.xml
+
+-runsystemcapabilities: ${native_capability}
+
+-resolve.effective: active
+
+
+-runfw: org.apache.felix.framework
+
+-runee: JavaSE-21
+
+-runrequires: \
+	bnd.identity;id='${project.artifactId}-tests',\
+	bnd.identity;id='${project.artifactId}'
+
+# -runbundles is calculated by the bnd-resolver-maven-plugin
+-runbundles: \
+	assertj-core;version='[3.26.0,3.26.1)',\
+	junit-jupiter-api;version='[5.10.2,5.10.3)',\
+	junit-jupiter-engine;version='[5.10.2,5.10.3)',\
+	junit-jupiter-params;version='[5.10.2,5.10.3)',\
+	junit-platform-commons;version='[1.10.2,1.10.3)',\
+	junit-platform-engine;version='[1.10.2,1.10.3)',\
+	junit-platform-launcher;version='[1.10.2,1.10.3)',\
+	net.bytebuddy.byte-buddy;version='[1.14.16,1.14.17)',\
+	org.apache.felix.configadmin;version='[1.9.26,1.9.27)',\
+	org.apache.felix.scr;version='[2.2.10,2.2.11)',\
+	org.eclipse.daanse.rdb.structure.api;version='[0.0.1,0.0.2)',\
+	org.eclipse.daanse.rdb.structure.emf;version='[0.0.1,0.0.2)',\
+	org.eclipse.daanse.rdb.structure.emf-tests;version='[0.0.1,0.0.2)',\
+	org.eclipse.emf.common;version='[2.30.0,2.30.1)',\
+	org.eclipse.emf.ecore;version='[2.36.0,2.36.1)',\
+	org.eclipse.emf.ecore.xmi;version='[2.37.0,2.37.1)',\
+	org.gecko.emf.osgi.component;version='[6.2.0,6.2.1)',\
+	org.opentest4j;version='[1.3.0,1.3.1)',\
+	org.osgi.service.component;version='[1.5.1,1.5.2)',\
+	org.osgi.test.common;version='[1.3.0,1.3.1)',\
+	org.osgi.test.junit5;version='[1.3.0,1.3.1)',\
+	org.osgi.test.junit5.cm;version='[1.3.0,1.3.1)',\
+	org.osgi.util.converter;version='[1.0.9,1.0.10)',\
+	org.osgi.util.function;version='[1.2.0,1.2.1)',\
+	org.osgi.util.promise;version='[1.3.0,1.3.1)'

--- a/structure.modifier.emf/pom.xml
+++ b/structure.modifier.emf/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<!--
+/*********************************************************************
+* Copyright (c) 2024 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+**********************************************************************/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.eclipse.daanse</groupId>
+    <artifactId>org.eclipse.daanse.rdb</artifactId>
+    <version>${revision}</version>
+  </parent>
+  <artifactId>org.eclipse.daanse.rdb.structure.modifier.emf</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.eclipse.daanse</groupId>
+      <artifactId>org.eclipse.daanse.rdb.structure.api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.daanse</groupId>
+      <artifactId>org.eclipse.daanse.rolap.mapping.emf</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.daanse</groupId>
+      <artifactId>org.eclipse.daanse.emf.model.rolapmapping</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.daanse</groupId>
+      <artifactId>org.eclipse.daanse.rdb.modifier</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/structure.modifier.emf/src/main/java/org/eclipse/daanse/rdb/structure/modifier/emf/EmfMappingModifier.java
+++ b/structure.modifier.emf/src/main/java/org/eclipse/daanse/rdb/structure/modifier/emf/EmfMappingModifier.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *
+ */
+package org.eclipse.daanse.rdb.structure.modifier.emf;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.eclipse.daanse.emf.model.rdbstructure.RelationalDatabaseFactory;
+import org.eclipse.daanse.rdb.modifier.AbstractMappingModifier;
+import org.eclipse.daanse.rdb.structure.api.model.Column;
+import org.eclipse.daanse.rdb.structure.api.model.DatabaseCatalog;
+import org.eclipse.daanse.rdb.structure.api.model.DatabaseSchema;
+import org.eclipse.daanse.rdb.structure.api.model.Link;
+import org.eclipse.daanse.rdb.structure.api.model.PhysicalTable;
+import org.eclipse.daanse.rdb.structure.api.model.SystemTable;
+import org.eclipse.daanse.rdb.structure.api.model.Table;
+import org.eclipse.daanse.rdb.structure.api.model.ViewTable;
+
+public class EmfMappingModifier extends AbstractMappingModifier {
+
+    protected EmfMappingModifier(DatabaseCatalog catalog) {
+        super(catalog);
+    }
+
+    @Override
+    protected Link createLink(Column primaryKey, Column foreignKey) {
+        org.eclipse.daanse.emf.model.rdbstructure.Link link = RelationalDatabaseFactory.eINSTANCE.createLink();
+        link.setPrimaryKey((org.eclipse.daanse.emf.model.rdbstructure.Column) primaryKey);
+        link.setForeignKey((org.eclipse.daanse.emf.model.rdbstructure.Column) foreignKey);
+        return link;
+    }
+
+    @Override
+    protected Column createColumn(
+        String name, Table table, String type, List<String> typeQualifiers,
+        String description
+    ) {
+        org.eclipse.daanse.emf.model.rdbstructure.Column column = RelationalDatabaseFactory.eINSTANCE.createColumn();
+        column.setName(name);
+        column.setTable((org.eclipse.daanse.emf.model.rdbstructure.Table) table);
+        column.setType(type);
+        column.getTypeQualifiers().addAll(typeQualifiers);
+        column.setDescription(description);
+        return column;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    protected ViewTable createViewTable(
+        String name, List<? extends Column> columns, DatabaseSchema schema,
+        String description
+    ) {
+        org.eclipse.daanse.emf.model.rdbstructure.ViewTable viewTable =
+            RelationalDatabaseFactory.eINSTANCE.createViewTable();
+        viewTable.setName(name);
+        viewTable.getColumns().addAll((Collection<? extends org.eclipse.daanse.emf.model.rdbstructure.Column>) columns);
+        viewTable.setSchema((org.eclipse.daanse.emf.model.rdbstructure.DatabaseSchema) schema);
+        viewTable.setDescription(description);
+        return viewTable;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    protected SystemTable createSystemTable(
+        String name, List<? extends Column> columns, DatabaseSchema schema,
+        String description
+    ) {
+        org.eclipse.daanse.emf.model.rdbstructure.SystemTable systemTable =
+            RelationalDatabaseFactory.eINSTANCE.createSystemTable();
+        systemTable.setName(name);
+        systemTable.getColumns().addAll((Collection<? extends org.eclipse.daanse.emf.model.rdbstructure.Column>) columns);
+        systemTable.setSchema((org.eclipse.daanse.emf.model.rdbstructure.DatabaseSchema) schema);
+        systemTable.setDescription(description);
+        return systemTable;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    protected PhysicalTable createPhysicalTable(
+        String name, List<? extends Column> columns, DatabaseSchema schema,
+        String description
+    ) {
+        org.eclipse.daanse.emf.model.rdbstructure.PhysicalTable physicalTable =
+            RelationalDatabaseFactory.eINSTANCE.createPhysicalTable();
+        physicalTable.setName(name);
+        physicalTable.getColumns().addAll((Collection<? extends org.eclipse.daanse.emf.model.rdbstructure.Column>) columns);
+        physicalTable.setSchema((org.eclipse.daanse.emf.model.rdbstructure.DatabaseSchema) schema);
+        physicalTable.setDescription(description);
+        return physicalTable;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    protected DatabaseSchema createDatabaseSchema(List<? extends Table> tables, String name, String id) {
+        org.eclipse.daanse.emf.model.rdbstructure.DatabaseSchema databaseSchema =
+            RelationalDatabaseFactory.eINSTANCE.createDatabaseSchema();
+        databaseSchema.getTables().addAll((Collection<? extends org.eclipse.daanse.emf.model.rdbstructure.Table>) tables);
+        databaseSchema.setName(name);
+        databaseSchema.setId(id);
+        return databaseSchema;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    protected DatabaseCatalog createCatalog(List<? extends DatabaseSchema> schemas, List<? extends Link> links) {
+        org.eclipse.daanse.emf.model.rdbstructure.DatabaseCatalog databaseCatalog = RelationalDatabaseFactory.eINSTANCE.createDatabaseCatalog();
+        databaseCatalog.getSchemas().addAll((Collection<? extends org.eclipse.daanse.emf.model.rdbstructure.DatabaseSchema>) schemas);
+        databaseCatalog.getLinks().addAll((Collection<? extends org.eclipse.daanse.emf.model.rdbstructure.Link>) links);
+        return databaseCatalog;
+    }
+
+}


### PR DESCRIPTION
should now be possible for emf-generator that we use this in rolap from other repo. so we can bring it back from emf.model repo